### PR TITLE
feat: state variable of eDT does not include deleted columns anymore

### DIFF
--- a/editbl/DESCRIPTION
+++ b/editbl/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: editbl
 Type: Package
-Version: 1.1.0
+Version: 1.1.0-9000
 Date: 2025-01-31
 Title: 'DT' Extension for CRUD (Create, Read, Update, Delete) Applications in 'shiny'
 Authors@R: c(person("Jasper", "Schelfhout", "", "jasper.schelfhout@openanalytics.eu",

--- a/editbl/R/eDT.R
+++ b/editbl/R/eDT.R
@@ -1185,7 +1185,7 @@ eDTServer <- function(
         
         return(list(
                 result = result,
-                state = reactive({castToTemplate(rv$modifiedData[,dataVars()], data())}),
+                state = reactive({castToTemplate(rv$modifiedData[!rv$modifiedData[[deleteCol]],dataVars()], data())}),
                 selected = reactive({castToTemplate(selected()[,dataVars()], data())})
             ))
       }

--- a/editbl/inst/NEWS
+++ b/editbl/inst/NEWS
@@ -1,3 +1,5 @@
+1.1.0-9000
+	o State variable of eDT output does not contain deleted rows anymore.
 1.1.0
 	o Allow to block edits and deletes with row-specific logic.
 	o More performance since buttons get generated on row basis instead of dataset basis.


### PR DESCRIPTION
The "state" variable of the output of the eDT function still contained the deleted rows.

This excludes the deleted rows from the "state" variable, to correctly reflect the current state of the eDT table.