### PR TITLE
feat: Allow setting column order for full table (incl foreignTbls)

### DIFF
--- a/editbl/DESCRIPTION
+++ b/editbl/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: editbl
 Type: Package
-Version: 1.1.0-9000
+Version: 1.1.0-9001
 Date: 2025-01-31
 Title: 'DT' Extension for CRUD (Create, Read, Update, Delete) Applications in 'shiny'
 Authors@R: c(person("Jasper", "Schelfhout", "", "jasper.schelfhout@openanalytics.eu",

--- a/editbl/R/eDT.R
+++ b/editbl/R/eDT.R
@@ -64,7 +64,7 @@ eDTOutput <- function(id,...) {
 #' @param format function accepting and returning a \code{\link[DT]{datatable}}
 #' @param in_place `logical`. Whether to modify the data object in place or to return a modified copy.
 #' @param foreignTbls `list`. List of objects created by \code{\link{foreignTbl}}
-#' @param columnOrder `vector`. Order of columns (both from original data and foreignTbls. Defaults to no order specified.
+#' @param columnOrder `vector`. Order of columns, original data and foreignTbls combined. Defaults to no order specified.
 #' @param statusColor named `character`. Colors to indicate status of the row.
 #' @param inputUI `function`. UI function of a shiny module with at least arguments `id` `data` and `...`.
 #' #'   elements with inputIds identical to one of the column names are used to update the data.

--- a/editbl/R/eDT.R
+++ b/editbl/R/eDT.R
@@ -64,7 +64,7 @@ eDTOutput <- function(id,...) {
 #' @param format function accepting and returning a \code{\link[DT]{datatable}}
 #' @param in_place `logical`. Whether to modify the data object in place or to return a modified copy.
 #' @param foreignTbls `list`. List of objects created by \code{\link{foreignTbl}}
-#' @param foreignTblsColumnOrder `vector`. Order of columns (both from original data and foreignTbls. Defaults to no order specified.
+#' @param columnOrder `vector`. Order of columns (both from original data and foreignTbls. Defaults to no order specified.
 #' @param statusColor named `character`. Colors to indicate status of the row.
 #' @param inputUI `function`. UI function of a shiny module with at least arguments `id` `data` and `...`.
 #' #'   elements with inputIds identical to one of the column names are used to update the data.
@@ -163,7 +163,7 @@ eDT <- function(
     in_place = FALSE,
     format = function(x){x},
     foreignTbls = list(),
-    foreignTblsColumnOrder = c(),
+    columnOrder = c(),
     statusColor = c("insert"="#e6e6e6", "update"="#32a6d3", "delete"="#e52323"),
     inputUI = editbl::inputUI,
     defaults = tibble(),
@@ -237,7 +237,7 @@ eDTServer <- function(
     in_place = FALSE,
     format = function(x){x},
     foreignTbls = list(),
-    foreignTblsColumnOrder = c(),
+    columnOrder = c(),
     statusColor = c("insert"="#e6e6e6", "update"="#32a6d3", "delete"="#e52323"),
     inputUI = editbl::inputUI,
     defaults = tibble(),
@@ -378,8 +378,8 @@ eDTServer <- function(
           foreignTbls <- shiny::reactive(foreignTbls, env = argEnv)
         }
         
-        if(!shiny::is.reactive(foreignTblsColumnOrder)){
-          foreignTblsColumnOrder <- shiny::reactive(foreignTblsColumnOrder, env = argEnv)
+        if(!shiny::is.reactive(columnOrder)){
+          columnOrder <- shiny::reactive(columnOrder, env = argEnv)
         }
         
         if(!shiny::is.reactive(statusColor)){
@@ -447,19 +447,19 @@ eDTServer <- function(
               }
               
               # Order the columns of the full dataframe
-              if (length(foreignTblsColumnOrder()) > 0) {
-                if (length( setdiff(foreignTblsColumnOrder(), names(data)) ) > 0) {
-                  warning(sprintf("The foreignTblsColumnOrder contains columns that are not present in the data. Ignoring the following redundant columns: %s.",
-                      paste(setdiff(foreignTblsColumnOrder(), names(data)), collapse = ", ")))
-                  columnOrder <- foreignTblsColumnOrder()[foreignTblsColumnOrder() %in% names(data)]
-                  data <- data %>% dplyr::select(columnOrder)
-                } else if (length( setdiff(names(data), foreignTblsColumnOrder()) ) > 0) {
-                  warning(sprintf("Not all columns are included in the foreignTblsColumnOrder. Adding the following missing columns to the right of the table: %s.",
-                      paste(setdiff(names(data), foreignTblsColumnOrder()), collapse = ", ")))
-                  columnOrder <- c(foreignTblsColumnOrder(), setdiff(names(data), foreignTblsColumnOrder()))
-                  data <- data %>% dplyr::select(columnOrder)
+              if (length(columnOrder()) > 0) {
+                if (length( setdiff(columnOrder(), names(data)) ) > 0) {
+                  warning(sprintf("The columnOrder variable contains columns that are not present in the data. Ignoring the following redundant columns: %s.",
+                      paste(setdiff(columnOrder(), names(data)), collapse = ", ")))
+                  colOrder <- columnOrder()[columnOrder() %in% names(data)]
+                  data <- data %>% dplyr::select(colOrder)
+                } else if (length( setdiff(names(data), columnOrder()) ) > 0) {
+                  warning(sprintf("Not all columns are included in the columnOrder. Adding the following missing columns to the right of the table: %s.",
+                      paste(setdiff(names(data), columnOrder()), collapse = ", ")))
+                  colOrder <- c(columnOrder(), setdiff(names(data), columnOrder()))
+                  data <- data %>% dplyr::select(colOrder)
                 } else {
-                  data <- data %>% dplyr::select(foreignTblsColumnOrder())
+                  data <- data %>% dplyr::select(columnOrder())
                 }
               }
               

--- a/editbl/inst/NEWS
+++ b/editbl/inst/NEWS
@@ -1,5 +1,6 @@
-1.1.0-9000
+1.1.0-9001
 	o State variable of eDT output does not contain deleted rows anymore.
+	o Allow to order the columns of the full table (including columns from foreignTbls).
 1.1.0
 	o Allow to block edits and deletes with row-specific logic.
 	o More performance since buttons get generated on row basis instead of dataset basis.

--- a/editbl/man/eDT.Rd
+++ b/editbl/man/eDT.Rd
@@ -33,7 +33,7 @@ eDT(
      x
  },
   foreignTbls = list(),
-  foreignTblsColumnOrder = c(),
+  columnOrder = c(),
   statusColor = c(insert = "#e6e6e6", update = "#32a6d3", delete = "#e52323"),
   inputUI = editbl::inputUI,
   defaults = tibble(),
@@ -179,7 +179,7 @@ set for all \code{Date} columns.}
 
 \item{foreignTbls}{\code{list}. List of objects created by \code{\link{foreignTbl}}}
 
-\item{foreignTblsColumnOrder}{\code{vector}. Order of columns (both from original data and foreignTbls. Defaults to no order specified.}
+\item{columnOrder}{\code{vector}. Order of columns (both from original data and foreignTbls. Defaults to no order specified.}
 
 \item{statusColor}{named \code{character}. Colors to indicate status of the row.}
 

--- a/editbl/man/eDT.Rd
+++ b/editbl/man/eDT.Rd
@@ -33,6 +33,7 @@ eDT(
      x
  },
   foreignTbls = list(),
+  foreignTblsColumnOrder = c(),
   statusColor = c(insert = "#e6e6e6", update = "#32a6d3", delete = "#e52323"),
   inputUI = editbl::inputUI,
   defaults = tibble(),
@@ -177,6 +178,8 @@ set for all \code{Date} columns.}
 \item{format}{function accepting and returning a \code{\link[DT]{datatable}}}
 
 \item{foreignTbls}{\code{list}. List of objects created by \code{\link{foreignTbl}}}
+
+\item{foreignTblsColumnOrder}{\code{vector}. Order of columns (both from original data and foreignTbls. Defaults to no order specified.}
 
 \item{statusColor}{named \code{character}. Colors to indicate status of the row.}
 

--- a/editbl/tests/testthat/test-eDT.R
+++ b/editbl/tests/testthat/test-eDT.R
@@ -98,7 +98,7 @@ test_that("working with selectInputDT works.", {
           foreignTbls = list(
             foreignTbl(songs, artists, by = "artist_id", naturalKey = c("first_name", "last_name"))
           ),
-          foreignTblsColumnOrder = c("artist_id", "last_name", "first_name", "song")    
+          columnOrder = c("artist_id", "last_name", "first_name", "song")    
         )
       }
       

--- a/editbl/tests/testthat/test-eDT.R
+++ b/editbl/tests/testthat/test-eDT.R
@@ -94,10 +94,12 @@ test_that("working with selectInputDT works.", {
       ui <- eDTOutput("app")
       server <- function(input,output,session){
         eDTServer(id = "app",
-            data = songs,
-            foreignTbls = list(
-                foreignTbl(songs, artists, by = "artist_id", naturalKey = c("first_name", "last_name"))
-                ))
+          data = songs,
+          foreignTbls = list(
+            foreignTbl(songs, artists, by = "artist_id", naturalKey = c("first_name", "last_name"))
+          ),
+          foreignTblsColumnOrder = c("artist_id", "last_name", "first_name", "song")    
+        )
       }
       
       # Test if using edit a second time still works


### PR DESCRIPTION
Allow setting the order of the full table (including columns originating from foreignTbls).

Resolves feature request: #5 