### PR TITLE
FIX: castToTemplate in case of empty template

### DIFF
--- a/editbl/DESCRIPTION
+++ b/editbl/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: editbl
 Type: Package
-Version: 1.2.0
+Version: 1.2.0-9000
 Date: 2025-03-28
 Title: 'DT' Extension for CRUD (Create, Read, Update, Delete) Applications in 'shiny'
 Authors@R: c(person("Jasper", "Schelfhout", "", "jasper.schelfhout@openanalytics.eu",

--- a/editbl/R/utils.R
+++ b/editbl/R/utils.R
@@ -144,11 +144,11 @@ castToTemplate <- function(x, template){
   
   templateRow <- dplyr::collect(dplyr::filter(template, dplyr::row_number()==1))
   # In case the template is empty, templateRow will only contain the format (without content)
+  # Add an empty row to make sure that the format will be correctly inherited
   if (nrow(templateRow) == 0) {
-    result <- rbind(templateRow,x)
-  } else {
-    result <- rbind(templateRow,x)[-1,]
+    templateRow[1,] <- NA
   }
+  result <- rbind(templateRow,x)[-1,]
   
   # Tbl doesn't properly support row names
   if(!inherits(template, 'tbl')){

--- a/editbl/R/utils.R
+++ b/editbl/R/utils.R
@@ -142,10 +142,13 @@ castToTemplate <- function(x, template){
   
   rowNames <- attr(x, 'row.names')
   
-  result <- rbind(
-      dplyr::collect(dplyr::filter(template, dplyr::row_number()==1)),
-      x
-  )[-1,]
+  templateRow <- dplyr::collect(dplyr::filter(template, dplyr::row_number()==1))
+  # In case the template is empty, templateRow will only contain the format (without content)
+  if (nrow(templateRow) == 0) {
+    result <- rbind(templateRow,x)
+  } else {
+    result <- rbind(templateRow,x)[-1,]
+  }
   
   # Tbl doesn't properly support row names
   if(!inherits(template, 'tbl')){

--- a/editbl/inst/NEWS
+++ b/editbl/inst/NEWS
@@ -1,3 +1,5 @@
+1.2.0-9000
+	o FIX: castToTemplate removed first row of adapted data in case the template was empty.
 1.2.0
 	o FIX: State variable of eDT output does not contain deleted rows anymore.
 	o FEAT: Allow to order the columns of the full table (including columns from foreignTbls). ([issue](https://github.com/openanalytics/editbl/issues/5))

--- a/editbl/tests/testthat/test-utils.R
+++ b/editbl/tests/testthat/test-utils.R
@@ -83,9 +83,19 @@ test_that("castToTemplate can cast from data.frame to data.table",{
       result <- castToTemplate(x = iris, template = data.table::data.table(iris))
       expect_equal(result, data.table::as.data.table(iris))
     })
+  
+test_that("castToTemplate can cast from data.frame to data.table with empty template",{
+      result <- castToTemplate(x = iris, template = data.table::data.table(iris[0,]))
+      expect_equal(result, data.table::as.data.table(iris))
+    })
 
 test_that("castToTemplate can cast from data.frame to tbl",{
       result <- castToTemplate(x = iris,  template = dplyr::as_tibble(iris))
+      expect_equal(result, dplyr::as_tibble(iris))
+    })
+  
+test_that("castToTemplate can cast from data.frame to tbl with empty template",{
+      result <- castToTemplate(x = iris,  template = dplyr::as_tibble(iris[0,]))
       expect_equal(result, dplyr::as_tibble(iris))
     })
 
@@ -93,9 +103,19 @@ test_that("castToTemplate can cast from tbl to data.frame",{
       result <- castToTemplate(x = dplyr::as_tibble(iris), template = iris)
       expect_equal(result, iris)
     })
+  
+test_that("castToTemplate can cast from tbl to data.frame with empty template",{
+      result <- castToTemplate(x = dplyr::as_tibble(iris), template = iris[0,])
+      expect_equal(result, iris)
+    })
 
 test_that("castToTemplate can cast from data.table to data.frame",{
       result <- castToTemplate(x = data.table::as.data.table(iris), template = iris)
+      expect_equal(result, iris)
+    })
+  
+test_that("castToTemplate can cast from data.table to data.frame with empty template",{
+      result <- castToTemplate(x = data.table::as.data.table(iris), template = iris[0,])
       expect_equal(result, iris)
     })
 
@@ -103,9 +123,19 @@ test_that("castToTemplate can cast from data.table to tbl",{
       result <- castToTemplate(x = data.table::as.data.table(iris), template = dplyr::as_tibble(iris))
       expect_equal(result, dplyr::as_tibble(iris))
     })
+  
+test_that("castToTemplate can cast from data.table to tbl with empty template",{
+      result <- castToTemplate(x = data.table::as.data.table(iris), template = dplyr::as_tibble(iris[0,]))
+      expect_equal(result, dplyr::as_tibble(iris))
+    })
 
 test_that("castToTemplate can cast from tbl to data.table",{
       result <- castToTemplate(x = dplyr::as_tibble(iris), template = data.table::as.data.table(iris))
+      expect_equal(result, data.table::as.data.table(iris))
+    })
+  
+test_that("castToTemplate can cast from tbl to data.table with empty template",{
+      result <- castToTemplate(x = iris, template = data.table::as.data.table(iris[0,]))
       expect_equal(result, data.table::as.data.table(iris))
     })
 


### PR DESCRIPTION
In case the original data is an empty table (i.e. no rows), the castToTemplate function removed the first row of the adapted data.

This pr makes sure that castToTemplate works as expected for both filled and empty template data.