### PR TITLE
FIX: saving changes for single-column data

### DIFF
--- a/editbl/DESCRIPTION
+++ b/editbl/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: editbl
 Type: Package
 Version: 1.3.1
-Date: 2025-04-23
+Date: 2025-09-24
 Title: 'DT' Extension for CRUD (Create, Read, Update, Delete) Applications in 'shiny'
 Authors@R: c(person("Jasper", "Schelfhout", "", "jasper.schelfhout@openanalytics.eu",
            role = c("aut", "cre")),

--- a/editbl/R/eDT.R
+++ b/editbl/R/eDT.R
@@ -816,7 +816,7 @@ eDTServer <- function(
         
         observeEvent(input$DT_cell_edit, {
               rv$edits <- input$DT_cell_edit
-              rv$edits_react <-  rv$edits_react + 1
+              rv$edits_react <- rv$edits_react + 1
             })
         
         observeEvent(rv$edits_react, {
@@ -1080,7 +1080,7 @@ eDTServer <- function(
               }
             })
         
-        observeEvent(input$confirmCommit, {              
+        observeEvent(input$confirmCommit, {     
               req(!is.null(effectiveChanges()) && isTruthy(effectiveChanges()))
               modified <- effectiveChanges()
               cols <- as.character(dplyr::tbl_vars(data()))
@@ -1119,7 +1119,7 @@ eDTServer <- function(
                     if(!checkForeignTbls(inserted, foreignTbls())){
                       stop("You made invalid edits to a row.")
                     }
-                    inserted <- inserted[,cols]
+                    inserted <- inserted[,cols,drop=FALSE]
                     
                     if(nrow(deleted)){
                       if(inherits(result, 'tbl_dbi') & in_place()){
@@ -1149,14 +1149,15 @@ eDTServer <- function(
                         DBI::dbRemoveTable(dbplyr::remote_con(result), temp_name)
                       }
                     }
+					
                     if(nrow(edited)){
                       result <- e_rows_update(
                           x = result,
                           y = edited,
                           match = match,
                           by = keys(),
-                          in_place = in_place())
-                    }
+                          in_place = in_place())				  
+                    }					
                     
                     if(nrow(inserted)){
 # Needed code should there be a switch to dbplyr::rows_insert
@@ -1187,7 +1188,7 @@ eDTServer <- function(
                     }
                     
                     rv$committedData <- result
-                    
+					
                     # Set modified and rendered to comitted version
                     # re-read data in case of in_place modification
                     # This is because certain backends might modify the row further with defaults etc.

--- a/editbl/inst/NEWS
+++ b/editbl/inst/NEWS
@@ -1,5 +1,6 @@
 1.3.1
 	o Remove non-exported functions from documentation.
+	o FIX: saving changes for single-column data
 1.3.0
     o FIX: castToTemplate removed first row of adapted data in case the template was empty.
     o FEAT: Add a clone button for each row.

--- a/editbl/tests/testthat/test-eDT.R
+++ b/editbl/tests/testthat/test-eDT.R
@@ -36,10 +36,20 @@ test_that("Editing a single table column works", {
           app = eDTServer,
           args = list(data = data),
           expr = {
-            session$setInputs(edit_row_1 = 1)       
-            session$setInputs(confirmCommit = 1)
+			# Make a cell edit
+			session$setInputs(DT_cell_edit = data.frame( 
+					row = 1,
+					col = 1,
+					value = 3
+					))
+			session$flushReact() 
+            
+			# Save changes
+			session$setInputs(confirmCommit = 1)
+			session$flushReact() 
+						
+			expect_true(rv$modifiedData[1,'one_column'] == 3)
           })
-      expect_true(TRUE)
     })
 
 test_that("Deletion of a row works", {

--- a/editbl/tests/testthat/test-eDT.R
+++ b/editbl/tests/testthat/test-eDT.R
@@ -49,6 +49,7 @@ test_that("Editing a single table column works", {
 			session$flushReact() 
 						
 			expect_true(rv$modifiedData[1,'one_column'] == 3)
+			expect_true(rv$resultMessage == 'success.')		
           })
     })
 


### PR DESCRIPTION
For single-column data saving changes resulted in `Failure: argument is of length zero`