### PR TITLE
feat: hide buttons when canXXXRow argument is FALSE.

### DIFF
--- a/editbl/DESCRIPTION
+++ b/editbl/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: editbl
 Type: Package
 Version: 1.3.1
-Date: 2025-09-24
+Date: 2025-09-30
 Title: 'DT' Extension for CRUD (Create, Read, Update, Delete) Applications in 'shiny'
 Authors@R: c(person("Jasper", "Schelfhout", "", "jasper.schelfhout@openanalytics.eu",
            role = c("aut", "cre")),

--- a/editbl/R/eDT.R
+++ b/editbl/R/eDT.R
@@ -1647,13 +1647,13 @@ createCloneButtonHTML <- function(
 
 #' Re-usable documentation
 #' @param canEditRow can be either of the following:
-#'    - `logical`, e.g. TRUE or FALSE
+#'    - `logical`, e.g. TRUE or FALSE. In case of `FALSE`, buttons will not be visible except for new rows.
 #'    - `function`. Needs as input an argument `row` which accepts a single row `tibble` and as output TRUE/FALSE.
 #' @param canCloneRow can be either of the following:
-#'    - `logical`, e.g. TRUE or FALSE
+#'    - `logical`, e.g. TRUE or FALSE. In case of `FALSE`, buttons will not be visible except for new rows.
 #'    - `function`. Needs as input an argument `row` which accepts a single row `tibble` and as output TRUE/FALSE.
 #' @param canDeleteRow can be either of the following:
-#'    - `logical`, e.g. TRUE or FALSE
+#'    - `logical`, e.g. TRUE or FALSE. In case of `FALSE`, buttons will not be visible except for new rows.
 #'    - `function`. Needs as input an argument `row` which accepts a single row `tibble` and as output TRUE/FALSE.
 #' @keywords internal
 canXXXRowTemplate <- function(canEditRow, canCloneRow, canDeleteRow){
@@ -1679,19 +1679,45 @@ createButtons <- function(
     canCloneRow = TRUE,
     statusCol = '_editbl_status'
 ){
-  deleteButton <- createDeleteButtonHTML(
-      ns=ns,
-      suffix=suffix,
-      disabled = !evalCanDeleteRow(row=row, canDeleteRow=canDeleteRow, statusCol=statusCol))
-  editButton <- createEditButtonHTML(
-       ns=ns,
-       suffix=suffix,
-       disabled = !evalCanEditRow(row=row, canEditRow=canEditRow, statusCol=statusCol))
-  cloneButton <- createCloneButtonHTML(
-    ns = ns,
-    suffix = suffix,
-    disabled = !evalCanCloneRow(row = row, canCloneRow = canCloneRow, statusCol = statusCol))
-
+  # Hide delete completely if canDeleteRow = FALSE. With the exception of newly created rows.
+  if(is.logical(canDeleteRow) 
+	&& !canDeleteRow 
+	&& (is.null(statusCol) || row[[statusCol]] != 'inserted')
+  ){
+    deleteButton <- ""
+  } else {
+    deleteButton <- createDeleteButtonHTML(
+			  ns=ns,
+			  suffix=suffix,
+			  disabled = !evalCanDeleteRow(row=row, canDeleteRow=canDeleteRow, statusCol=statusCol))
+  }
+  
+  # Hide edit completely if canEditRow = FALSE. With the exception of newly created rows.
+  if(is.logical(canEditRow) 
+		  && !canEditRow 
+		  && (is.null(statusCol) || row[[statusCol]] != 'inserted')
+		  ){
+	  editButton <- ""
+  } else {
+	  editButton <- createEditButtonHTML(
+			  ns=ns,
+			  suffix=suffix,
+			  disabled = !evalCanEditRow(row=row, canEditRow=canEditRow, statusCol=statusCol))
+  }
+  
+  # Hide clone button completely if canCloneRow = FALSE. With the exception of newly created rows.
+  if(is.logical(canCloneRow) 
+		  && !canCloneRow 
+		  && (is.null(statusCol) || row[[statusCol]] != 'inserted')
+		  ){
+	  cloneButton <- ""
+  } else {
+	  cloneButton <- createCloneButtonHTML(
+			  ns = ns,
+			  suffix = suffix,
+			  disabled = !evalCanCloneRow(row = row, canCloneRow = canCloneRow, statusCol = statusCol))
+  }
+  
   result <- sprintf('<div class="btn-group">%1$s%2$s%3$s</div>',
       deleteButton,
       editButton,

--- a/editbl/inst/NEWS
+++ b/editbl/inst/NEWS
@@ -1,6 +1,7 @@
 1.3.1
 	o Remove non-exported functions from documentation.
 	o FIX: saving changes for single-column data
+	o FEAT: hide buttons when canXXXRow argument is FALSE.
 1.3.0
     o FIX: castToTemplate removed first row of adapted data in case the template was empty.
     o FEAT: Add a clone button for each row.

--- a/editbl/man/addButtons.Rd
+++ b/editbl/man/addButtons.Rd
@@ -26,19 +26,19 @@ addButtons(
 
 \item{canEditRow}{can be either of the following:
 \itemize{
-\item \code{logical}, e.g. TRUE or FALSE
+\item \code{logical}, e.g. TRUE or FALSE. In case of \code{FALSE}, buttons will not be visible except for new rows.
 \item \code{function}. Needs as input an argument \code{row} which accepts a single row \code{tibble} and as output TRUE/FALSE.
 }}
 
 \item{canDeleteRow}{can be either of the following:
 \itemize{
-\item \code{logical}, e.g. TRUE or FALSE
+\item \code{logical}, e.g. TRUE or FALSE. In case of \code{FALSE}, buttons will not be visible except for new rows.
 \item \code{function}. Needs as input an argument \code{row} which accepts a single row \code{tibble} and as output TRUE/FALSE.
 }}
 
 \item{canCloneRow}{can be either of the following:
 \itemize{
-\item \code{logical}, e.g. TRUE or FALSE
+\item \code{logical}, e.g. TRUE or FALSE. In case of \code{FALSE}, buttons will not be visible except for new rows.
 \item \code{function}. Needs as input an argument \code{row} which accepts a single row \code{tibble} and as output TRUE/FALSE.
 }}
 

--- a/editbl/man/canXXXRowTemplate.Rd
+++ b/editbl/man/canXXXRowTemplate.Rd
@@ -9,19 +9,19 @@ canXXXRowTemplate(canEditRow, canCloneRow, canDeleteRow)
 \arguments{
 \item{canEditRow}{can be either of the following:
 \itemize{
-\item \code{logical}, e.g. TRUE or FALSE
+\item \code{logical}, e.g. TRUE or FALSE. In case of \code{FALSE}, buttons will not be visible except for new rows.
 \item \code{function}. Needs as input an argument \code{row} which accepts a single row \code{tibble} and as output TRUE/FALSE.
 }}
 
 \item{canCloneRow}{can be either of the following:
 \itemize{
-\item \code{logical}, e.g. TRUE or FALSE
+\item \code{logical}, e.g. TRUE or FALSE. In case of \code{FALSE}, buttons will not be visible except for new rows.
 \item \code{function}. Needs as input an argument \code{row} which accepts a single row \code{tibble} and as output TRUE/FALSE.
 }}
 
 \item{canDeleteRow}{can be either of the following:
 \itemize{
-\item \code{logical}, e.g. TRUE or FALSE
+\item \code{logical}, e.g. TRUE or FALSE. In case of \code{FALSE}, buttons will not be visible except for new rows.
 \item \code{function}. Needs as input an argument \code{row} which accepts a single row \code{tibble} and as output TRUE/FALSE.
 }}
 }

--- a/editbl/man/createButtons.Rd
+++ b/editbl/man/createButtons.Rd
@@ -23,19 +23,19 @@ createButtons(
 
 \item{canEditRow}{can be either of the following:
 \itemize{
-\item \code{logical}, e.g. TRUE or FALSE
+\item \code{logical}, e.g. TRUE or FALSE. In case of \code{FALSE}, buttons will not be visible except for new rows.
 \item \code{function}. Needs as input an argument \code{row} which accepts a single row \code{tibble} and as output TRUE/FALSE.
 }}
 
 \item{canDeleteRow}{can be either of the following:
 \itemize{
-\item \code{logical}, e.g. TRUE or FALSE
+\item \code{logical}, e.g. TRUE or FALSE. In case of \code{FALSE}, buttons will not be visible except for new rows.
 \item \code{function}. Needs as input an argument \code{row} which accepts a single row \code{tibble} and as output TRUE/FALSE.
 }}
 
 \item{canCloneRow}{can be either of the following:
 \itemize{
-\item \code{logical}, e.g. TRUE or FALSE
+\item \code{logical}, e.g. TRUE or FALSE. In case of \code{FALSE}, buttons will not be visible except for new rows.
 \item \code{function}. Needs as input an argument \code{row} which accepts a single row \code{tibble} and as output TRUE/FALSE.
 }}
 

--- a/editbl/man/eDT.Rd
+++ b/editbl/man/eDT.Rd
@@ -194,19 +194,19 @@ It will be evaluated for each cloned row in the environment defined by 'env'.}
 
 \item{canEditRow}{can be either of the following:
 \itemize{
-\item \code{logical}, e.g. TRUE or FALSE
+\item \code{logical}, e.g. TRUE or FALSE. In case of \code{FALSE}, buttons will not be visible except for new rows.
 \item \code{function}. Needs as input an argument \code{row} which accepts a single row \code{tibble} and as output TRUE/FALSE.
 }}
 
 \item{canDeleteRow}{can be either of the following:
 \itemize{
-\item \code{logical}, e.g. TRUE or FALSE
+\item \code{logical}, e.g. TRUE or FALSE. In case of \code{FALSE}, buttons will not be visible except for new rows.
 \item \code{function}. Needs as input an argument \code{row} which accepts a single row \code{tibble} and as output TRUE/FALSE.
 }}
 
 \item{canCloneRow}{can be either of the following:
 \itemize{
-\item \code{logical}, e.g. TRUE or FALSE
+\item \code{logical}, e.g. TRUE or FALSE. In case of \code{FALSE}, buttons will not be visible except for new rows.
 \item \code{function}. Needs as input an argument \code{row} which accepts a single row \code{tibble} and as output TRUE/FALSE.
 }}
 

--- a/editbl/man/initData.Rd
+++ b/editbl/man/initData.Rd
@@ -31,19 +31,19 @@ initData(
 
 \item{canDeleteRow}{can be either of the following:
 \itemize{
-\item \code{logical}, e.g. TRUE or FALSE
+\item \code{logical}, e.g. TRUE or FALSE. In case of \code{FALSE}, buttons will not be visible except for new rows.
 \item \code{function}. Needs as input an argument \code{row} which accepts a single row \code{tibble} and as output TRUE/FALSE.
 }}
 
 \item{canEditRow}{can be either of the following:
 \itemize{
-\item \code{logical}, e.g. TRUE or FALSE
+\item \code{logical}, e.g. TRUE or FALSE. In case of \code{FALSE}, buttons will not be visible except for new rows.
 \item \code{function}. Needs as input an argument \code{row} which accepts a single row \code{tibble} and as output TRUE/FALSE.
 }}
 
 \item{canCloneRow}{can be either of the following:
 \itemize{
-\item \code{logical}, e.g. TRUE or FALSE
+\item \code{logical}, e.g. TRUE or FALSE. In case of \code{FALSE}, buttons will not be visible except for new rows.
 \item \code{function}. Needs as input an argument \code{row} which accepts a single row \code{tibble} and as output TRUE/FALSE.
 }}
 }


### PR DESCRIPTION
This indicates that the user never wants to use this feature of editbl. Thus completely hiding the buttons provides cleaner UI. This won't be a breaking change since people can still provide `function(...){FALSE}`  instead of just `FALSE` in case the old behavior is preferred.